### PR TITLE
Added MPI_Finalize to test_pent.f90

### DIFF
--- a/pyranda/parcop/test_pent.f90
+++ b/pyranda/parcop/test_pent.f90
@@ -5,19 +5,19 @@ PROGRAM test_pent
   USE LES_patch, ONLY : patch_type
   USE LES_comm, ONLY : comm_type, LES_comm_world
   USE LES_mesh, ONLY : mesh_type
-  USE LES_objects 
+  USE LES_objects
   USE parcop, ONLY : setup,ddx,point_to_objects,setup_mesh
   IMPLICIT NONE
   INCLUDE "mpif.h"
 
-  
+
   INTEGER(c_int)                 :: nx,ny,nz,px,py,pz
   REAL(c_double)                 :: x1,xn,y1,yn,z1,zn
   CHARACTER(KIND=c_char,LEN=4)   :: bx1,bxn,by1,byn,bz1,bzn
   REAL(c_double)                 :: simtime
   INTEGER(c_int)                 :: world_id,world_np,mpierr
   REAL(c_double), DIMENSION(:,:,:), ALLOCATABLE :: rho,drho
-  INTEGER :: i 
+  INTEGER :: i
   INTEGER :: t1,t2,clock_rate,clock_max
   CHARACTER(LEN=32) :: arg
   INTEGER :: nargs,ii,iterations
@@ -28,7 +28,7 @@ PROGRAM test_pent
   CALL MPI_COMM_RANK(MPI_COMM_WORLD,rank,ierror)
 
   nargs = command_argument_count()
-  
+
   ! Print usage:
   IF ( rank == 0 .AND. nargs == 0) THEN
      PRINT*,"USAGE:"
@@ -38,7 +38,7 @@ PROGRAM test_pent
      PRINT*,"./test_pent 100 32 1 32 1 32 1"
      PRINT*,"mpirun -n 8 ./test_pent 100 64 2 64 2 64 2"
   ENDIF
-  
+
   ! Default domain, grid and processors map
   x1 = 0.0
   xn = 1.0
@@ -56,7 +56,7 @@ PROGRAM test_pent
   px = 1
   py = 1
   pz = 1
-  
+
   ! Iterations
   iterations = 100
 
@@ -64,7 +64,7 @@ PROGRAM test_pent
   ii=1
   IF (nargs >= ii) CALL GETARG(ii,arg)
   IF (nargs >= ii) READ(arg,'(I10)') iterations
-  
+
   ii=ii+1
   IF (nargs >= ii) CALL GETARG(ii,arg)
   IF (nargs >= ii) READ(arg,'(I10)') nx
@@ -89,15 +89,15 @@ PROGRAM test_pent
   IF (nargs >= ii) CALL GETARG(ii,arg)
   IF (nargs >= ii) READ(arg,'(I10)') pz
 
-  
-  
+
+
   bx1 = "NONE"
   bxn = "NONE"
   by1 = "NONE"
   byn = "NONE"
   bz1 = "NONE"
   bzn = "NONE"
-  
+
   simtime = 0.0D0
 
   ! Setup matrices/solvers
@@ -110,14 +110,14 @@ PROGRAM test_pent
   ! Allocated some arrays
   ALLOCATE( rho(nx/px,ny/py,nz/pz) )
   ALLOCATE(drho(nx/px,ny/py,nz/pz) )
-  
+
   ! rho = x
   rho = mesh_ptr%xgrid
 
   ! Time the derivatives
   CALL SYSTEM_CLOCK( t1, clock_rate, clock_max)
   DO i=1,iterations
-     CALL ddx(rho,drho,nx/px,ny/py,nz/pz)    
+     CALL ddx(rho,drho,nx/px,ny/py,nz/pz)
   END DO
   CALL SYSTEM_CLOCK( t2, clock_rate, clock_max)
 
@@ -125,9 +125,8 @@ PROGRAM test_pent
   IF ( rank == 0 ) THEN
      print*,'Ellapsed time = ', real(t2-t1) / real(clock_rate)
   END IF
-  
+
   CALL remove_objects(0,0)
+  CALL MPI_FINALIZE(mpierr)
 
 END PROGRAM test_pent
-
-


### PR DESCRIPTION
Added MPI_Finalize call at the end of the program, runs weren't completing properly without it because there was no blocking call at the end.

Other edits because of automatic delete-trailing-whitespace tool.