### PR TITLE
Add support for manual specification of domain decomposition

### DIFF
--- a/pyranda/pyrandaMPI.py
+++ b/pyranda/pyrandaMPI.py
@@ -32,6 +32,11 @@ class pyrandaMPI():
         self.nx = meshOptions['nn'][0]
         self.ny = meshOptions['nn'][1]
         self.nz = meshOptions['nn'][2]
+
+        doManualDecompose = meshOptions['manualDomainDecomposition']
+        manualPx = meshOptions['pn'][0]
+        manualPy = meshOptions['pn'][1]
+        manualPz = meshOptions['pn'][2]
         
         x1 = meshOptions['x1'][0]
         xn = meshOptions['xn'][0]
@@ -70,9 +75,15 @@ class pyrandaMPI():
         self.filter_type = ('compact', 'compact', 'compact')
         
 
-        # Compute the domain decomposition
-        [px,py,pz] = decomp( self.comm.Get_size(),
-                             self.nx, self.ny, self.nz )
+        if (doManualDecompose == True):
+            # Decompose based on user-supplied arguments
+            px = manualPx
+            py = manualPy
+            pz = manualPz
+        else:
+            # Compute the domain decomposition
+            [px,py,pz] = decomp( self.comm.Get_size(),
+                                 self.nx, self.ny, self.nz )
 
         if (px*py*pz != self.comm.Get_size()):
             if self.comm.Get_rank() == 0:

--- a/pyranda/pyrandaMPI.py
+++ b/pyranda/pyrandaMPI.py
@@ -32,7 +32,7 @@ class pyrandaMPI():
         self.nx = meshOptions['nn'][0]
         self.ny = meshOptions['nn'][1]
         self.nz = meshOptions['nn'][2]
-
+        
         x1 = meshOptions['x1'][0]
         xn = meshOptions['xn'][0]
         y1 = meshOptions['x1'][1]

--- a/pyranda/pyrandaMPI.py
+++ b/pyranda/pyrandaMPI.py
@@ -33,11 +33,6 @@ class pyrandaMPI():
         self.ny = meshOptions['nn'][1]
         self.nz = meshOptions['nn'][2]
 
-        doManualDecompose = meshOptions['manualDomainDecomposition']
-        manualPx = meshOptions['pn'][0]
-        manualPy = meshOptions['pn'][1]
-        manualPz = meshOptions['pn'][2]
-        
         x1 = meshOptions['x1'][0]
         xn = meshOptions['xn'][0]
         y1 = meshOptions['x1'][1]
@@ -74,12 +69,16 @@ class pyrandaMPI():
         self.order = (10,10,10)
         self.filter_type = ('compact', 'compact', 'compact')
         
+        # Check if we're doing a manual decomposition
+        doManualDecompose = ( (meshOptions['pn'][0] >= 1) or (self.nx == 1) and
+                              (meshOptions['pn'][1] >= 1) or (self.ny == 1) and
+                              (meshOptions['pn'][2] >= 1) or (self.nz == 1) )        
 
         if (doManualDecompose == True):
             # Decompose based on user-supplied arguments
-            px = manualPx
-            py = manualPy
-            pz = manualPz
+            px = max(meshOptions['pn'][0],1)
+            py = max(meshOptions['pn'][1],1)
+            pz = max(meshOptions['pn'][2],1)
         else:
             # Compute the domain decomposition
             [px,py,pz] = decomp( self.comm.Get_size(),

--- a/pyranda/pyrandaMesh.py
+++ b/pyranda/pyrandaMesh.py
@@ -179,10 +179,10 @@ def defaultMeshOptions():
     options['coordsys'] = 0
     options['function'] = None
     options['id'] = 0
-    # Options to enable manual control of domain processor decomposition
-    # Set manualDomainDecomposition = True to tell Pyranda to just use pn = [ px,py,pz ] as number of processors in x, y, and z
+
+    # Option to enable manual control of domain processor decomposition
+    # Set to tell Pyranda to just use pn = [ px,py,pz ] as number of processors in x, y, and z
     # instead of attempting to decompose automatically
-    options['manualDomainDecomposition'] = False
-    options['pn'] = [1, 1, 1] # Number of processors to use in x, y, and z
+    options['pn'] = [0, 0, 0] # Number of processors to use in x, y, and z
     
     return options

--- a/pyranda/pyrandaMesh.py
+++ b/pyranda/pyrandaMesh.py
@@ -179,5 +179,12 @@ def defaultMeshOptions():
     options['coordsys'] = 0
     options['function'] = None
     options['id'] = 0
+    # Options to enable manual control of domain processor decomposition
+    # Set manualDomainDecomposition = True to tell Pyranda to just use px,py,pz as number of processors in x, y, and z
+    # instead of attempting to decompose automatically
+    options['manualDomainDecomposition'] = False
+    options['px'] = 1
+    options['py'] = 1
+    options['pz'] = 1
     
     return options

--- a/pyranda/pyrandaMesh.py
+++ b/pyranda/pyrandaMesh.py
@@ -180,11 +180,9 @@ def defaultMeshOptions():
     options['function'] = None
     options['id'] = 0
     # Options to enable manual control of domain processor decomposition
-    # Set manualDomainDecomposition = True to tell Pyranda to just use px,py,pz as number of processors in x, y, and z
+    # Set manualDomainDecomposition = True to tell Pyranda to just use pn = [ px,py,pz ] as number of processors in x, y, and z
     # instead of attempting to decompose automatically
     options['manualDomainDecomposition'] = False
-    options['px'] = 1
-    options['py'] = 1
-    options['pz'] = 1
+    options['pn'] = [1, 1, 1] # Number of processors to use in x, y, and z
     
     return options


### PR DESCRIPTION
This adds the new default options:
```
manualDomainDecomposition = False
pn = [1, 1, 1]
```

With default arguments, no behavior changes and the automatic decomposition method is used.

Changing `manualDomainDecomposition` to `True` will use the values specified in `pn[0]`, `pn[1]` and `pn[2]` as the number of processors in x, y, and z respectively. This then goes through the same sanity checking that the automatic process would.

I have tested this manually with a 3D input deck and verified that a situation where automatic decomposition fails (with `manualDomainDecomposition = False`) successfully runs when setting the option to True and with suitable processor numbers in each axis. I haven't created an automated test, but one could be created if needed.

This pull request would close #66 