### PR TITLE
Fix CI Runners

### DIFF
--- a/examples/RT3D.py
+++ b/examples/RT3D.py
@@ -245,6 +245,14 @@ ss.write(outVars)
 mixW  = []
 timeW = []
 
+# numpy.trapz was renamed to numpy.trapezoid in NumPy 2.0. The old name still
+# exists in 2.x but is deprecated; the new name doesn't exist before 2.0.
+# Bind whichever this NumPy version offers.
+try:
+    _trapezoid = numpy.trapezoid
+except AttributeError:
+    _trapezoid = numpy.trapz
+
 while time < tstop:
 
     # Update the EOM and get next dt
@@ -257,7 +265,7 @@ while time < tstop:
     ss.iprint("%s -- %s --- Umax: %s " % (ss.cycle,time,umax)  ) 
 
     if ( ss.cycle%viz_freq == 0):
-        mixW.append( numpy.trapezoid( ss.var('mix').mean( axis=[1,2] ) , ss.var('meshx')[:,0,0] )   )
+        mixW.append( _trapezoid( ss.var('mix').mean( axis=[1,2] ) , ss.var('meshx')[:,0,0] )   )
         timeW.append( time )
     
     if not test:


### PR DESCRIPTION
This PR abstracts `numpy.trapezoid` in the `examples/RT3D.py` case to be either `numpy.trapz` or `numpy.trapezoid` depending on what is available in the current `numpy` version.